### PR TITLE
Add phone_number param to User#update

### DIFF
--- a/lib/frontegg/user.rb
+++ b/lib/frontegg/user.rb
@@ -19,9 +19,11 @@ module Frontegg
       client.execute_request(:put, url, body: { tenantId: tenant_id })
     end
 
-    def update(email: nil, name: nil, metadata: {})
+    def update(email: nil, name: nil, metadata: {}, phone_number: nil)
       if name
-        client.execute_request(:put, resource_url, body: { name:, metadata: metadata.to_json })
+        body = { name:, metadata: metadata.to_json }
+        body[:phoneNumber] = phone_number if phone_number
+        client.execute_request(:put, resource_url, body:)
       elsif email
         client.execute_request(:put, "#{resource_url}/email", body: { email: })
       end


### PR DESCRIPTION
## Summary
- Add `phone_number:` keyword argument to `Frontegg::User#update`
- When provided alongside `name`, includes `phoneNumber` in the PUT body sent to Frontegg API

## Context
Part of PLAT-1713: syncing phone numbers to Frontegg when users update their profile.

## Test plan
- [ ] Verify Frontegg PUT request includes `phoneNumber` when `phone_number:` is passed
- [ ] Verify existing name/email update behavior is unchanged when `phone_number` is nil