### PR TITLE
Relax jwt constraint to allow 2.10.3 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,14 @@ PATH
   specs:
     frontegg (0.0.1)
       faraday (~> 2.12)
-      jwt (~> 2.7.1, >= 2)
+      jwt (~> 2.7, >= 2.7.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.3.0)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
@@ -21,7 +22,8 @@ GEM
       net-http
     hashdiff (1.0.1)
     json (2.10.2)
-    jwt (2.7.1)
+    jwt (2.10.3)
+      base64
     logger (1.6.6)
     net-http (0.4.1)
       uri

--- a/frontegg.gemspec
+++ b/frontegg.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
 
   s.add_dependency 'faraday', '~> 2.12'
-  s.add_dependency 'jwt', '~> 2.7.1', '>= 2'
+  s.add_dependency 'jwt', '~> 2.7', '>= 2.7.1'
 end


### PR DESCRIPTION
## Why

The current gemspec pins `jwt', '~> 2.7.1', '>= 2'`, and `~> 2.7.1` caps jwt at `< 2.8`. That pin is the sole blocker preventing hint-api from taking a jwt security fix — hint-api's Dependabot alert wants **jwt 2.10.3**, but the frontegg gem (pulled in via git ref) forces re-resolution back to 2.7.x.

## What

Relax the constraint to `~> 2.7, >= 2.7.1` (= `>= 2.7.1, < 3.0`), so the jwt 2.x line can advance while staying on major 2. Lockfile bumped to jwt 2.10.3.

## Compatibility

frontegg's only use of the jwt gem is a single call in `lib/frontegg/client.rb`:

```ruby
JWT.decode(token, nil, false).first['exp']
```

An unverified decode to read the `exp` claim. `JWT.decode`'s signature is unchanged across the entire jwt 2.x line (and 3.x), so 2.10.3 is a drop-in. All 30 specs pass against 2.10.3.

## Test plan

- [x] `bundle update jwt` resolves to 2.10.3
- [x] `bundle exec rspec` — 30 examples, 0 failures

## Follow-up

Once merged, hint-api bumps its frontegg git ref + jwt to 2.10.3 to close its high-severity Dependabot alert (#163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)